### PR TITLE
Use lock on writing to websockets. 

### DIFF
--- a/high_templar/room.py
+++ b/high_templar/room.py
@@ -23,12 +23,14 @@ class Subscription:
         if self.connection.ws.closed:
             raise WebSocketClosedError
 
+        message = json.dumps({
+            'requestId': self.requestId,
+            'type': 'publish',
+            'data': data,
+        })
+
         with self.connection._write_lock:
-            self.connection.ws.send(json.dumps({
-                'requestId': self.requestId,
-                'type': 'publish',
-                'data': data,
-            }))
+            self.connection.ws.send(message)
 
     def stop(self):
         self.room.remove_subscription(self)


### PR DESCRIPTION
Hopefully fixes the following error:

`feb 13 13:28:07 boek-prod sockserv[20838]: gevent.exceptions.ConcurrentObjectUseError: This socket is already used by another greenlet: <bound method Waiter.switch of <gevent.__waiter.Waiter object at 0x7`