### PR TITLE
Make requirements restrictions less strict

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,14 +34,14 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules'
     ],
     install_requires=[
-        'python-dotenv == 0.21.1',
-        'aio-pika == 9.3.1',
-        'hypercorn == 0.14.3',
-        'quart == 0.11.2',
-        'frozendict == 2.4.6',
-        'aiohttp == 3.11.10',
-        'Jinja2 == 3.0.3',
-        'werkzeug == 2.1.2',
+        'python-dotenv >= 0.21.1',
+        'aio-pika >= 9.3.1',
+        'hypercorn >= 0.14.3',
+        'quart >= 0.11.2',
+        'frozendict >= 2.4.6',
+        'aiohttp >= 3.11.10',
+        'Jinja2 >= 3.0.3',
+        'werkzeug >= 2.1.2',
     ],
     test_suite='tests'
 )


### PR DESCRIPTION
This makes the requirement restrictions less strict, such that requirements can be upgraded by the user using the package. This makes it possible to more easily run in different environments.

With this change it is also possible to run it in python 3.13 on debian 13, using the following requirements:

```
werkzeug==3.1.3
quart==0.20.0
Jinja2==3.1.2
```